### PR TITLE
Limit pickling for a selected top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Add `Compiled by morty` comment to output files (with version and datetime)
+- `top_module` parameter to restrict pickled output and output manifest to the needed files for module hierarchy
 
 ## 0.7.0 - 2022-08-09
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +383,7 @@ dependencies = [
  "clap",
  "colored",
  "log",
+ "petgraph",
  "pulldown-cmark",
  "rayon",
  "serde",
@@ -569,6 +576,16 @@ name = "os_str_bytes"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ colored = "2.0.0"
 pulldown-cmark = "0.9"
 rayon = "1.3"
 chrono = "0.4"
+petgraph = "0.6"
 
 [lib]
 name = "morty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "morty"
 version = "0.7.0"
 description = "A SystemVerilog source file pickler."
-authors = ["Florian Zaruba <zarubaf@iis.ee.ethz.ch>", "Fabian Schuiki <fschuiki@iis.ee.ethz.ch>"]
+authors = ["Florian Zaruba <zarubaf@iis.ee.ethz.ch>", "Fabian Schuiki <fschuiki@iis.ee.ethz.ch>", "Michael Rogenmoser <michaero@iis.ee.ethz.ch>"]
 edition = "2018"
 license-file = "LICENSE"
 keywords = ["hardware-dev", "system-verilog"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,22 @@ pub fn write_manifest(
     Ok(())
 }
 
+/// Write module graph to file
+pub fn write_dot_graph(pickle: &Pickle, graph_file: &str) -> Result<()> {
+    let path = Path::new(graph_file);
+    let mut out = Box::new(BufWriter::new(File::create(&path).unwrap())) as Box<dyn Write>;
+    writeln!(
+        out,
+        "{:?}",
+        petgraph::dot::Dot::with_config(
+            &pickle.module_graph,
+            &[petgraph::dot::Config::EdgeNoLabel]
+        )
+    )
+    .unwrap();
+    Ok(())
+}
+
 /// Struct containing information about
 /// what should be pickled and how.
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,13 @@ fn main() -> Result<()> {
                 .help("Output a JSON-encoded source information manifest to FILE")
                 .takes_value(true),
         )
+        .arg(
+            Arg::new("top_module")
+                .long("top")
+                .value_name("TOP_MODULE")
+                .help("Top module, strip all unneeded modules")
+                .takes_value(true),
+        )
         .get_matches();
 
     let logger_level = matches.occurrences_of("v");
@@ -291,12 +298,20 @@ fn main() -> Result<()> {
         library_bundle,
         syntax_trees,
         out,
+        matches.value_of("top_module"),
     )?;
 
     // if the user requested a manifest we need to compute the information and output it in json
     // form
     if let Some(manifest_file) = matches.value_of("manifest") {
-        write_manifest(manifest_file, pickle, file_list, include_dirs, defines)?;
+        write_manifest(
+            manifest_file,
+            pickle,
+            file_list,
+            include_dirs,
+            defines,
+            matches.value_of("top_module"),
+        )?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,13 @@ fn main() -> Result<()> {
                 .help("Top module, strip all unneeded modules")
                 .takes_value(true),
         )
+        .arg(
+            Arg::new("graph_file")
+                .long("graph_file")
+                .value_name("FILE")
+                .help("Output a DOT graph of the parsed modules")
+                .takes_value(true),
+        )
         .get_matches();
 
     let logger_level = matches.occurrences_of("v");
@@ -300,6 +307,10 @@ fn main() -> Result<()> {
         out,
         matches.value_of("top_module"),
     )?;
+
+    if let Some(graph_file) = matches.value_of("graph_file") {
+        write_dot_graph(&pickle, graph_file)?;
+    }
 
     // if the user requested a manifest we need to compute the information and output it in json
     // form


### PR DESCRIPTION
Adds `top_module` parameter to pickle only for a selected top module, accordingly adjusting the pickle and output manifest.
As a graph is built either way, this also allows exporting of a DOT graph of instantiated modules.