### PR TITLE
Propagate defines and allow sequential processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add switch to disable parallel file parsing (can help with STACKOVERFLOW)
+
 ### Fixed
 - correct global package parsing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- remove defines from pickled output, with flag to keep
 
 ## 0.8.0 - 2022-08-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- correct global package parsing
+
 ### Changed
 - remove defines from pickled output, with flag to keep
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Add switch to disable parallel file parsing (can help with STACKOVERFLOW)
+- Add switch to propagate defines from parsed files to subsequent files
 
 ### Fixed
 - correct global package parsing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub fn do_pickle<'a>(
     mut out: Box<dyn Write>,
     top_module: Option<&'a str>,
     keep_defines: bool,
+    propagate_defines: bool,
 ) -> Result<Pickle<'a>> {
     let mut pickle = Pickle::new(
         // Collect renaming options.
@@ -191,11 +192,15 @@ pub fn do_pickle<'a>(
     )
     .unwrap();
 
-    match top_module {
-        Some(top) => {
+    if let Some(top) = top_module {
+        if !propagate_defines {
             pickle.prune_graph(top)?;
+        } else {
+            warn!(
+                "Not pruning for top_module {} due to propagate_defines.",
+                top
+            );
         }
-        None => {}
     }
 
     let needed_files = pickle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,40 +321,26 @@ pub fn build_syntax_tree(
         let bundle_include_dirs: Vec<_> = bundle.include_dirs.iter().map(Path::new).collect();
         let bundle_defines = defines_to_sv_parser(&bundle.defines);
 
-        if ignore_unparseable {
-            let v: Vec<ParsedFile> = bundle
-                .files
-                .par_iter()
-                .map(|filename| -> Result<_> {
-                    parse_file(
-                        filename,
-                        &bundle_include_dirs,
-                        &bundle_defines,
-                        strip_comments,
-                    )
-                })
-                .filter_map(|r| r.map_err(|e| warn!("Continuing with {:?}", e)).ok())
-                .collect();
-            syntax_trees.extend(v);
+        // For each file in the file bundle preprocess and parse it.
+        // Use a neat trick of `collect` here, which allows you to collect a
+        // `Result<T>` iterator into a `Result<Vec<T>>`, i.e. bubbling up the
+        // error.
+        let v = bundle.files.par_iter().map(|filename| -> Result<_> {
+            parse_file(
+                filename,
+                &bundle_include_dirs,
+                &bundle_defines,
+                strip_comments,
+            )
+        });
+
+        let v = if ignore_unparseable {
+            v.filter_map(|r| r.map_err(|e| warn!("Continuing with {:?}", e)).ok())
+                .collect()
         } else {
-            // For each file in the file bundle preprocess and parse it.
-            // Use a neat trick of `collect` here, which allows you to collect a
-            // `Result<T>` iterator into a `Result<Vec<T>>`, i.e. bubbling up the
-            // error.
-            let v: Result<Vec<ParsedFile>> = bundle
-                .files
-                .par_iter()
-                .map(|filename| -> Result<_> {
-                    parse_file(
-                        filename,
-                        &bundle_include_dirs,
-                        &bundle_defines,
-                        strip_comments,
-                    )
-                })
-                .collect();
-            syntax_trees.extend(v?);
-        }
+            v.collect::<Result<Vec<ParsedFile>>>()?
+        };
+        syntax_trees.extend(v);
     }
 
     Ok(syntax_trees)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,14 +193,14 @@ pub fn do_pickle<'a>(
     .unwrap();
 
     if let Some(top) = top_module {
-        if !propagate_defines {
-            pickle.prune_graph(top)?;
-        } else {
+        if propagate_defines {
             warn!(
-                "Not pruning for top_module {} due to propagate_defines.",
+                "Pickle might be non-functional as some files can be excluded due to use of --top={}.\
+                \n\tThis might lead to required components being excluded. Use at your own risk!!!",
                 top
             );
         }
+        pickle.prune_graph(top)?;
     }
 
     let needed_files = pickle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub fn do_pickle<'a>(
                             &pf.ast,
                             unwrap_node!(package_import, SimpleIdentifier).unwrap(),
                         );
-                        warn!(
+                        eprintln!(
                             "Global package import in {}:\n\t{}",
                             &pf.path,
                             &pf.source[Locate::try_from(x).unwrap().offset
@@ -505,7 +505,7 @@ impl<'a> Pickle<'a> {
     /// Register a declaration such as a package or module.
     pub fn register_declaration(&mut self, syntax_tree: &SyntaxTree, id: RefNode, file: String) {
         let (module_name, loc) = get_identifier(syntax_tree, id);
-        println!("module_name: {:?}", module_name);
+        info!("module_name: {:?}", module_name);
         self.module_graph_nodes.insert(
             module_name.clone(),
             self.module_graph.add_node(module_name.clone()),
@@ -624,12 +624,6 @@ impl<'a> Pickle<'a> {
                 _ => (),
             }
         }
-
-        // for id.into_iter()
-        // .into_iter()
-        // .map(|sub_node| unwrap_node!(sub_node, SimpleIdentifier, EscapedIdentifier))
-        // .flatten()
-        // .any(|id| id == unwrapped_node)
     }
 
     /// Register a usage of the identifier.
@@ -899,7 +893,7 @@ pub fn get_calling_module(st: &SyntaxTree, node: RefNode) -> Option<(String, Loc
     }
     // println!("{}", st);
     // println!("{:?}", loc0);
-    println!("Possible global package import, not properly parsed! TODO MICHAERO better error reporting to fix issue, link all modules/packages/interfaces in file to the dependency.");
+    eprintln!("Possible global package import, not properly parsed! TODO MICHAERO better error reporting to fix issue, link all modules/packages/interfaces in file to the dependency.");
     // panic!("No calling module found.");
     None
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,10 @@ fn main() -> Result<()> {
                 .help("Prevents removal of `define statements."),
         )
         .arg(
+            Arg::new("propagate_defines")
+                .help("Propagate defines from first files to the following files. Incompatible with `--top`."),
+        )
+        .arg(
             Arg::new("sequential")
                 .short('q')
                 .help("Enforce sequential processing of files. Slows down performance, but can avoid STACK_OVERFLOW.")
@@ -289,6 +293,7 @@ fn main() -> Result<()> {
         &file_list,
         strip_comments,
         matches.is_present("ignore_unparseable"),
+        matches.is_present("propagate_defines"),
         matches.is_present("sequential"),
     )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,11 @@ fn main() -> Result<()> {
                 .long("keep_defines")
                 .help("Prevents removal of `define statements."),
         )
+        .arg(
+            Arg::new("sequential")
+                .short('q')
+                .help("Enforce sequential processing of files. Slows down performance, but can avoid STACK_OVERFLOW.")
+        )
         .get_matches();
 
     let logger_level = matches.occurrences_of("v");
@@ -284,6 +289,7 @@ fn main() -> Result<()> {
         &file_list,
         strip_comments,
         matches.is_present("ignore_unparseable"),
+        matches.is_present("sequential"),
     )?;
 
     let out = match matches.value_of("output") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,11 @@ fn main() -> Result<()> {
                 .short('i')
                 .help("Ignore files that cannot be parsed"),
         )
+        .arg(
+            Arg::new("keep_defines")
+                .long("keep_defines")
+                .help("Prevents removal of `define statements."),
+        )
         .get_matches();
 
     let logger_level = matches.occurrences_of("v");
@@ -315,6 +320,7 @@ fn main() -> Result<()> {
         syntax_trees,
         out,
         matches.value_of("top_module"),
+        matches.contains_id("keep_defines"),
     )?;
 
     if let Some(graph_file) = matches.value_of("graph_file") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
             Arg::new("top_module")
                 .long("top")
                 .value_name("TOP_MODULE")
-                .help("Top module, strip all unneeded modules")
+                .help("Top module, strips all unneeded files. Incompatible with `--propagate_defines`.")
                 .takes_value(true),
         )
         .arg(
@@ -168,11 +168,13 @@ fn main() -> Result<()> {
         )
         .arg(
             Arg::new("propagate_defines")
-                .help("Propagate defines from first files to the following files. Incompatible with `--top`."),
+                .long("propagate_defines")
+                .help("Propagate defines from first files to the following files. Enables sequential."),
         )
         .arg(
             Arg::new("sequential")
                 .short('q')
+                .long("sequential")
                 .help("Enforce sequential processing of files. Slows down performance, but can avoid STACK_OVERFLOW.")
         )
         .get_matches();
@@ -332,6 +334,7 @@ fn main() -> Result<()> {
         out,
         matches.value_of("top_module"),
         matches.contains_id("keep_defines"),
+        matches.is_present("propagate_defines"),
     )?;
 
     if let Some(graph_file) = matches.value_of("graph_file") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
             Arg::new("top_module")
                 .long("top")
                 .value_name("TOP_MODULE")
-                .help("Top module, strips all unneeded files. Incompatible with `--propagate_defines`.")
+                .help("Top module, strips all unneeded files. May be incompatible with `--propagate_defines`.")
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
### Added
- Add switch to disable parallel file parsing (can help with STACKOVERFLOW)
- Add switch to propagate defines from parsed files to subsequent files