### PR TITLE
Fix out-of-bounds error on `new_replace_table`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,12 +287,9 @@ pub fn do_pickle<'a>(
         new_replace_table.sort_by(|a, b| a.0.cmp(&b.0));
 
         // Error on overlapping -> correct overlapping!
-        for i in 0..new_replace_table.len() - 1 {
-            if new_replace_table[i].0 + new_replace_table[i].1 > new_replace_table[i + 1].0 {
-                eprintln!(
-                    "Offset error, please contact Michael\n{:?}",
-                    new_replace_table[i]
-                );
+        for window in new_replace_table.windows(2) {
+            if window[0].0 + window[0].1 > window[1].0 {
+                eprintln!("Offset error, please contact Michael\n{:?}", window[0]);
             }
         }
 


### PR DESCRIPTION
The `for i in 0..new_replace_table.len() - 1` loop gave me an "index out of bounds: the len is 0 but the index is 0" run-time error.  The problem is that the subtraction underflows when the length of the vector is zero, since the LHS is of type `usize`.  (The underflow would lead to an "attempt to subtract with overflow" run-time error with debug builds but not with release builds.)

This commit fixes the problem by ~~ensuring that `new_replace_table.len()` is at least one before applying the subtraction~~ using `.windows(2)` to get an iterator over overlapping subslices of length two. (EDIT: A more 'Rusty' solution came to my mind. :slightly_smiling_face: )